### PR TITLE
Tt 4908 add width and height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).  
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).  
 
+## Unreleased
+
+* [TT-4908] - Add ticket element width and height
+
 ## 1.5.0
 
 * [TT-4614] - Add image printing support for esc/pos

--- a/src/main/java/au/com/sealink/printing/ticket_printer/TicketElement.java
+++ b/src/main/java/au/com/sealink/printing/ticket_printer/TicketElement.java
@@ -5,6 +5,8 @@ import java.util.EnumSet;
 public class TicketElement {
     private int x = 0;
     private int y = 0;
+    private Integer width;
+    private Integer height;
     private String value = "";
     private int fontSize = 10;
     private Justification justification = Justification.LEFT;
@@ -113,5 +115,21 @@ public class TicketElement {
 
     public void setUnderline(Underline underline) {
         this.underline = underline;
+    }
+
+    public Integer getWidth() {
+        return width;
+    }
+
+    public void setWidth(Integer width) {
+        this.width = width;
+    }
+
+    public Integer getHeight() {
+        return height;
+    }
+
+    public void setHeight(Integer height) {
+        this.height = height;
     }
 }

--- a/src/main/java/au/com/sealink/printing/ticket_printer/printables/PrintableImageElement.java
+++ b/src/main/java/au/com/sealink/printing/ticket_printer/printables/PrintableImageElement.java
@@ -27,7 +27,6 @@ class PrintableImageElement extends PrintableElement {
                 element.getY(),
                 getWidth(),
                 getHeight(),
-                Color.red,
                 null  // no observer
         );
     }

--- a/src/main/java/au/com/sealink/printing/ticket_printer/printables/PrintableImageElement.java
+++ b/src/main/java/au/com/sealink/printing/ticket_printer/printables/PrintableImageElement.java
@@ -33,10 +33,18 @@ class PrintableImageElement extends PrintableElement {
     }
 
     private int getHeight() {
-        return (int) (img.getHeight(null) / printerResolution * fontMultiplier);
+        if (element.getHeight() != null) {
+            return (int)(element.getHeight());
+        } else {
+            return (int) (img.getHeight(null) / printerResolution * fontMultiplier);
+        }
     }
 
     private int getWidth() {
-        return (int) (img.getWidth(null) / printerResolution * fontMultiplier);
+        if (element.getWidth() != null) {
+            return (int)(element.getWidth());
+        } else {
+            return (int) (img.getWidth(null) / printerResolution * fontMultiplier);
+        }
     }
 }

--- a/src/main/java/au/com/sealink/printing/ticket_printer/printables/PrintableImageElement.java
+++ b/src/main/java/au/com/sealink/printing/ticket_printer/printables/PrintableImageElement.java
@@ -33,7 +33,7 @@ class PrintableImageElement extends PrintableElement {
 
     private int getHeight() {
         if (element.getHeight() != null) {
-            return (int)(element.getHeight());
+            return element.getHeight();
         } else {
             return (int) (img.getHeight(null) / printerResolution * fontMultiplier);
         }
@@ -41,7 +41,7 @@ class PrintableImageElement extends PrintableElement {
 
     private int getWidth() {
         if (element.getWidth() != null) {
-            return (int)(element.getWidth());
+            return element.getWidth();
         } else {
             return (int) (img.getWidth(null) / printerResolution * fontMultiplier);
         }

--- a/src/test/java/au/com/sealink/printing/ticket_printer/TicketElementTest.java
+++ b/src/test/java/au/com/sealink/printing/ticket_printer/TicketElementTest.java
@@ -34,4 +34,27 @@ public class TicketElementTest {
     assertEquals(imageString.substring(imageOffset), imageticket.getImageValue());
   }
 
+  @Test
+  public void testBasicGettersAndSetters() {
+    TicketElement element = new TicketElement();
+    element.setBold(true);
+    element.setInverted(false);
+    element.setItalic(true);
+    element.setJustification(Justification.CENTRE);
+    element.setX(10);
+    element.setY(1);
+    element.setFontSize(10);
+    element.setHeight(50);
+    element.setWidth(30);
+
+    assertTrue(element.isBold());
+    assertFalse(element.isInverted());
+    assertTrue(element.isItalic());
+    assertEquals(Justification.CENTRE, element.getJustification());
+    assertEquals(10, element.getX());
+    assertEquals(1, element.getY());
+    assertEquals(10, element.getFontSize());
+    assertEquals(50, (int)element.getHeight());
+    assertEquals(30, (int)element.getWidth());
+  }
 }


### PR DESCRIPTION
WHY
Add width and height for image elements
No longer print transparent pixels red